### PR TITLE
PRMT-4482

### DIFF
--- a/terraform/topic.tf
+++ b/terraform/topic.tf
@@ -70,6 +70,10 @@ resource "aws_sns_topic" "re_registrations_topic" {
 resource "aws_sns_topic_policy" "sns_cross_account_permissions_policy" {
   arn    = aws_sns_topic.re_registrations_topic.arn
   policy = data.aws_iam_policy_document.sns_cross_account_permissions_policy_doc.json
+
+  depends_on = [
+    data.aws_iam_policy_document.sns_cross_account_permissions_policy_doc
+  ]
 }
 
 resource "aws_sns_topic_policy" "deny_http" {


### PR DESCRIPTION
- Added dependency to `aws_sns_topic_policy`.

Encountering an error on the pipeline:

```terraform
│ Error: InvalidParameter: Invalid parameter: Policy Error: null
│ 	status code: 400, request id: ffa48eef-0849-5e3e-89ad-d0a7679a9323
│ 
│   with aws_sns_topic_policy.sns_cross_account_permissions_policy,
│   on topic.tf line 70, in resource "aws_sns_topic_policy" "sns_cross_account_permissions_policy":
│   70: resource "aws_sns_topic_policy" "sns_cross_account_permissions_policy" {
```